### PR TITLE
Feature/thmsn migrate bot to types

### DIFF
--- a/src/bank.ts
+++ b/src/bank.ts
@@ -55,7 +55,7 @@ export type BankPackTypeItemsOnly =
   | "items8"
   | "items9";
 
-/** @deprecated This is not used anywhere anymore. */
+/** @deprecated This is not used anywhere anymore. @see BankPackTypeItemsOnly */
 export type BankPackType = "gold" | BankPackTypeItemsOnly;
 
 declare global {

--- a/src/character.ts
+++ b/src/character.ts
@@ -1,7 +1,8 @@
 import type { BankPackTypeItemsOnly } from "./bank";
 import { CharacterWithEventsFunctions } from "./character-event";
 import type { CharacterEntity } from "./entities/character-entity";
-import type { ItemInfo } from "./items";
+import type { InventoryExchangeItemInfo, InventoryUpgradeCompoundItemInfo, ItemInfo } from "./items";
+import { BetterUXWrapper } from "./types/GTypes/utils";
 
 export type CharacterBankInfos =
   | ({
@@ -22,7 +23,7 @@ declare global {
 
       bank?: CharacterBankInfos;
 
-      items: Array<ItemInfo | null>;
+      items: Array<BetterUXWrapper<ItemInfo| InventoryExchangeItemInfo | InventoryUpgradeCompoundItemInfo | null>>;
       /** Amount of gold the player has in its inventory */
       gold: number;
       /** Amount of shells */

--- a/src/entities/character-entity.ts
+++ b/src/entities/character-entity.ts
@@ -1,6 +1,4 @@
 import {
-  InventoryExchangeItemInfo,
-  InventoryUpgradeCompoundItemInfo,
   ItemInfo,
   TradeItemInfo,
 } from "../items";

--- a/src/entities/character-entity.ts
+++ b/src/entities/character-entity.ts
@@ -20,7 +20,7 @@ export interface CharacterEntityCXInfos {
 }
 
 export type CharacterEntitySlotsInfos = {
-  [T in SlotType]: ItemInfo | InventoryExchangeItemInfo | InventoryUpgradeCompoundItemInfo | null;
+  [T in SlotType]: ItemInfo  | null;
 } & {
   [T in TradeSlotType]?: TradeItemInfo | null;
 };

--- a/src/entities/status-info.ts
+++ b/src/entities/status-info.ts
@@ -7,6 +7,17 @@ export type StatusInfoBase = {
   ms: number;
 };
 
+export type MonsterHuntStatusInfo = {
+  /** Number of monsters remaining to kill */
+  c: number;
+  dl: boolean;
+  /** The monster to be killed */
+  id: MonsterKey;
+  ms: number;
+  /** The server where the monster hunt is valid */
+  sn: string;
+}
+
 export type StatusInfo = {
   [T in ConditionKey]?: StatusInfoBase;
 } & {
@@ -84,16 +95,7 @@ export type StatusInfo = {
     ms: number;
     strong?: boolean;
   };
-  monsterhunt?: {
-    /** Number of monsters remaining to kill */
-    c: number;
-    dl: boolean;
-    /** The monster to be killed */
-    id: MonsterKey;
-    ms: number;
-    /** The server where the monster hunt is valid */
-    sn: string;
-  };
+  monsterhunt?: MonsterHuntStatusInfo;
   newcomersblessing?: {
     f: string;
     ms: number;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -24,3 +24,5 @@ export type DamageType = "magical" | "physical";
 
 export type RawEntity = MonsterEntity | CharacterEntity | NpcEntity | Character;
 export type Entity = BetterUXWrapper<RawEntity>;
+
+export * from "./entities/status-info";

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -386,6 +386,12 @@ declare global {
   function is_moving(entity: Entity): boolean;
   function is_on_cooldown(skill: string): boolean;
 
+  /** returns true if you are silenced or disabled */
+  function is_silenced(entity: Entity): boolean;
+
+  /** returns true if you are dead, stunned, fingered, stoned, deepfreezed or sleeping */
+  function is_disabled(entity: Entity): boolean;
+
   /**
    * If no ID is given, it will loot some chests.
    * @param id The ID of a chest (from `parent.chests`)

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,7 +3,7 @@ import { MonsterEntity } from "./entities/monster-entity";
 import { SlotType, TradeSlotType } from "./entities/slots";
 import { Entity } from "./entity";
 import { ItemInfo } from "./items";
-import { IPosition, PositionReal, PositionMovable, PositionSmart } from "./position";
+import { IPosition, PositionReal, PositionSmart, ICoordReal } from "./position";
 import { EventKey } from "./types/GTypes/events";
 import { BoosterKey, ItemKey } from "./types/GTypes/items";
 import { MapKey } from "./types/GTypes/maps";
@@ -622,14 +622,26 @@ declare global {
    * @param entity The moveable entity you want to check is movable
    * @returns TRUE if you can move there, FALSE otherwise
    */
-  export function can_move(position: PositionMovable): boolean;
+  export function can_move(
+    position: IPosition & {
+      going_x: number;
+      going_y: number;
+      base?: {
+        h: number;
+        v: number | null;
+        vn: number;
+      };
+    }
+  ): boolean;
+
   // export function can_move(position: PositionMovable & { base: EntityBase }): boolean;
+
   /**
-   * Checks if you can move your character to the given destination on your current map
+   * Checks if you can move your character to the given destination on your current map from your current position
    * @param destination A position object containing the destination coordinates
    * @returns TRUE if you can move there, FALSE otherwise
    */
-  export function can_move_to(destination: PositionReal): boolean;
+  export function can_move_to(destination: ICoordReal): boolean;
   /**
    * Checks if you can move your character to the given destination on your current map
    * @param x The x-coordinate that you want to move to

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -208,7 +208,7 @@ declare global {
     itemSlot2: number,
     itemSlot3: number,
     scrollSlot: number,
-    offeringSlot: number | null,
+    offeringSlot: number | null | undefined,
     onlyCalculate: true
   ): Promise<CompoundCalculateResponse>;
 
@@ -455,7 +455,7 @@ declare global {
   function upgrade(
     item_slot: number,
     scroll_slot: number,
-    offering_slot: number | null,
+    offering_slot: number | null | undefined,
     only_calculate: true
   ): Promise<{
     success: boolean;

--- a/src/game-event-api-response.ts
+++ b/src/game-event-api-response.ts
@@ -1,0 +1,29 @@
+import { TradeSlotType } from "./entity";
+import { MapKey, StandKey } from "./G";
+import { TradeItemInfo } from "./items";
+import { BetterUXWrapper } from "./types/GTypes/utils";
+
+export type ServersAndCharactersApiResponse = {
+  type: "servers_and_characters";
+  servers: [];
+  characters: [];
+};
+
+export type MerchantsApiResponse = {
+  type: "merchants";
+  chars: Array<{
+    map: MapKey;
+    cx: string; // cosmetics
+    skin: string;
+    slots: Partial<Record<TradeSlotType, TradeItemInfo>>;
+    name: string;
+    level: number;
+    afk: boolean | string;
+    server: string;
+    stand: StandKey | "cstand" /** computer stand */;
+    y: number;
+    x: number;
+  }>;
+};
+export type RawApiResponse = ServersAndCharactersApiResponse | MerchantsApiResponse;
+export type ApiResponse = BetterUXWrapper<RawApiResponse>;

--- a/src/game-event.ts
+++ b/src/game-event.ts
@@ -1,5 +1,6 @@
 import { HitData } from "./character-event";
 import { TradeSlotType } from "./entity";
+import { ApiResponse } from "./game-event-api-response";
 import { ItemInfo, TradeItemInfo } from "./items";
 import { TypedEventEmitter } from "./TypedEventEmitter";
 import { ItemKey, StandKey } from "./types/GTypes/items";
@@ -194,31 +195,7 @@ export interface GameEvents {
     receiver: string;
     cx: string; // hat999 // TODO: cosmetics key?
   };
-  api_response:
-    // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
-    // | { type: string }
-    // TODO: there is a lot of different types of api responses, depending on api call
-    | {
-        type: "servers_and_characters";
-        servers: [];
-        characters: [];
-      }
-    | {
-        type: "merchants";
-        chars: Array<{
-          map: MapKey;
-          cx: string; // cosmetics
-          skin: string;
-          slots: Partial<Record<TradeSlotType, TradeItemInfo>>;
-          name: string;
-          level: number;
-          afk: boolean | string;
-          server: string;
-          stand: StandKey | "cstand" /** computer stand */;
-          y: number;
-          x: number;
-        }>
-      };
+  api_response: ApiResponse;
 
   /** Item bought from Ponty */
   sbuy: {
@@ -263,3 +240,5 @@ export interface GameEvents {
   };
   hit: HitData;
 }
+
+export * from "./game-event-api-response";

--- a/src/game-event.ts
+++ b/src/game-event.ts
@@ -1,9 +1,8 @@
 import { HitData } from "./character-event";
-import { TradeSlotType } from "./entity";
 import { ApiResponse } from "./game-event-api-response";
-import { ItemInfo, TradeItemInfo } from "./items";
+import { ItemInfo } from "./items";
 import { TypedEventEmitter } from "./TypedEventEmitter";
-import { ItemKey, StandKey } from "./types/GTypes/items";
+import { ItemKey } from "./types/GTypes/items";
 import { MapKey } from "./types/GTypes/maps";
 import { NpcKey } from "./types/GTypes/npcs";
 

--- a/src/game-event.ts
+++ b/src/game-event.ts
@@ -1,7 +1,8 @@
 import { HitData } from "./character-event";
-import { ItemInfo } from "./items";
+import { TradeSlotType } from "./entity";
+import { ItemInfo, TradeItemInfo } from "./items";
 import { TypedEventEmitter } from "./TypedEventEmitter";
-import { ItemKey } from "./types/GTypes/items";
+import { ItemKey, StandKey } from "./types/GTypes/items";
 import { MapKey } from "./types/GTypes/maps";
 import { NpcKey } from "./types/GTypes/npcs";
 
@@ -194,13 +195,31 @@ export interface GameEvents {
     cx: string; // hat999 // TODO: cosmetics key?
   };
   api_response:
-    | any
+    // https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
+    // | { type: string }
+    // TODO: there is a lot of different types of api responses, depending on api call
     | {
-        type: string; // "servers_and_characters";
+        type: "servers_and_characters";
         servers: [];
         characters: [];
-        // TODO: there is a lot of different types of api responses, depending on api call
+      }
+    | {
+        type: "merchants";
+        chars: Array<{
+          map: MapKey;
+          cx: string; // cosmetics
+          skin: string;
+          slots: Partial<Record<TradeSlotType, TradeItemInfo>>;
+          name: string;
+          level: number;
+          afk: boolean | string;
+          server: string;
+          stand: StandKey | "cstand" /** computer stand */;
+          y: number;
+          x: number;
+        }>
       };
+
   /** Item bought from Ponty */
   sbuy: {
     /** Character who triggered the event */

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,45 @@
+import { Entity } from "./entity";
+
+export {}; // this is done to make global a module
+declare global {
+  /* eslint-disable no-var, vars-on-top */
+  var handle_command: undefined | ((command: string, args: string) => void);
+  var on_cm: undefined | ((from: string, data: any) => void);
+  // var on_map_click: undefined | ((x: number, y: number) => boolean);
+
+  /**
+   *
+   */
+  var on_party_invite: undefined | ((from: string) => void);
+
+  /**
+   * called by the inviter's name
+   * request = someone requesting to join your existing party
+   */
+  var on_party_request: undefined | ((from: string) => void);
+
+  var on_disappear: undefined | ((entity: Entity, data: unknown) => void);
+
+  /**
+   * called by the mage's name in PVE servers,
+   * in PVP servers magiport either succeeds or fails without consent
+   */
+  var on_magiport: undefined | ((from: string) => void);
+
+  /**
+   * if true is returned, the default move is cancelled
+   */
+  var on_map_click: undefined | ((x: number, y: number) => void);
+
+  /**
+   * called just before the CODE is destroyed
+   */
+  var on_destroy: undefined | (() => void);
+
+  /**
+   * the game calls this function at the best place in each game draw frame,
+   * so if you are playing the game at 60fps, this function gets called 60 times per second
+   */
+  var on_draw: undefined | (() => void);
+  /* eslint-enable no-var, vars-on-top */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,6 @@ export * from "./server";
 export * from "./skills";
 export * from "./TypedEventEmitter";
 export * from "./types/GTypes";
-export * from "./window";
+export * from "./global";
+export * from "./socket-events";
+export * from "./parent";

--- a/src/parent/index.ts
+++ b/src/parent/index.ts
@@ -1,11 +1,22 @@
 import { BankPacksInfos } from "../bank";
 import { CharacterEntity, MonsterEntity, NpcEntity } from "../entity";
 import { PartyCharacter } from "../functions";
-import { EventKey, GDropList, GDropMaps, GDropMonsters, GDropNormalDrops, ItemKey, MapKey, MonsterKey, SkillKey } from "../G";
+import {
+  EventKey,
+  GDropList,
+  GDropMaps,
+  GDropMonsters,
+  GDropNormalDrops,
+  ItemKey,
+  MapKey,
+  MonsterKey,
+  SkillKey,
+} from "../G";
 import { PositionReal } from "../position";
 import { ServerIdentifier, ServerRegion } from "../server";
 import { SocketWithEventsFunctions } from "../socket-events";
 import { BetterUXWrapper } from "../types/GTypes/utils";
+import { SEventsInfos } from "./sevent-info";
 
 /** Tracktrix informations */
 export interface Tracker {
@@ -70,95 +81,6 @@ export interface XServerInfos {
   port: number;
   region: string;
 }
-
-export type SMonsterEventLive = {
-  /** Is the monster currently available? */
-  live: true;
-
-  /** NOTE: Some event monsters don't have x and y (e.g.: Slenderman) */
-  x?: number;
-  y?: number;
-  map: MapKey;
-
-  hp: number;
-  max_hp: number;
-
-  /** The character name that the monster is currently attacking */
-  target?: string | null;
-  end?: Date;
-};
-
-// TODO: don't think all events has live / spawn when not live
-export type SMonsterEventNotLive = {
-  /** Is the monster currently available? */
-  live: false;
-
-  /** At what date will the monster spawn? */
-  spawn: string;
-};
-
-export type SMonsterEvent = BetterUXWrapper<SMonsterEventNotLive | SMonsterEventLive>;
-
-export type SEventBooleanKeys =
-  | "egghunt"
-  | "halloween"
-  | "holidayseason"
-  | "lunarnewyear"
-  | "valentines";
-
-export type SPartialEventBoolean = Partial<Record<Extract<SEventBooleanKeys, EventKey>, boolean>>;
-
-// TODO: should we just use MonsterKey?
-export type SPartialEventMonsterEvent = Partial<
-  Record<Exclude<EventKey, SEventBooleanKeys | "abtesting" | "goobrawl">, SMonsterEvent>
->;
-export type SPartialHolidaySeasonMonsters = Partial<Record<"grinch" | "snowman", SMonsterEvent>>;
-export type SPartialHalloweenMonsters = Partial<
-  Record<"mrpumpkin" | "mrgreen" | "slenderman", SMonsterEvent>
->;
-
-export type SPartialABTesting = Partial<
-  Record<
-    "abtesting",
-    {
-      /** A date string of when the event will end */
-      end?: string;
-
-      /** A date string of when sign-ups will stop for the event */
-      signup_end: string;
-      /** How many characters are on team A. TODO: Check that this is actually what it means */
-      A: number;
-      /** How many characters are on team B. TODO: Check that this is actually what it means */
-      B: number;
-      /** The event ID. TODO: Do we need this? */
-      id: string;
-    }
-  >
->;
-
-export type SPartialGooBrawlEventInfo = Partial<
-  Record<
-    "abtesting",
-    {
-      /** A date string of when the event will end */
-      end?: string;
-    }
-  >
->;
-
-export type SEventsInfos = {
-  schedule: {
-    time_offset: number;
-    dailies: Array<number>;
-    nightlies: Array<number>;
-    night: boolean;
-  };
-} & SPartialEventBoolean &
-  SPartialEventMonsterEvent &
-  SPartialHolidaySeasonMonsters &
-  SPartialHalloweenMonsters &
-  SPartialABTesting &
-  SPartialGooBrawlEventInfo;
 
 export {}; // this is done to make parent a module
 declare global {
@@ -229,3 +151,5 @@ export type ChestInfo = PositionReal & {
   alpha: number;
   skin: "chest3" | string;
 };
+
+export * from "./sevent-info";

--- a/src/parent/index.ts
+++ b/src/parent/index.ts
@@ -1,26 +1,11 @@
-import { BankPacksInfos } from "./bank";
-import { CharacterEntity } from "./entities/character-entity";
-import { MonsterEntity } from "./entities/monster-entity";
-import { NpcEntity } from "./entities/npc-entity";
-import { Entity } from "./entity";
-import { PartyCharacter } from "./functions";
-import {
-  MapKey,
-  GDropList,
-  GDropMaps,
-  GDropMonsters,
-  GDropNormalDrops,
-  ItemKey,
-  MonsterKey,
-  EventKey,
-} from "./G";
-import { PositionReal } from "./position";
-import { ServerIdentifier, ServerRegion } from "./server";
-import { SocketWithEventsFunctions } from "./socket-events";
-import { SkillKey } from "./types/GTypes/skills";
-import { BetterUXWrapper } from "./types/GTypes/utils";
-
-export * from "./socket-events";
+import { BankPacksInfos } from "../bank";
+import { CharacterEntity, MonsterEntity, NpcEntity } from "../entity";
+import { PartyCharacter } from "../functions";
+import { EventKey, GDropList, GDropMaps, GDropMonsters, GDropNormalDrops, ItemKey, MapKey, MonsterKey, SkillKey } from "../G";
+import { PositionReal } from "../position";
+import { ServerIdentifier, ServerRegion } from "../server";
+import { SocketWithEventsFunctions } from "../socket-events";
+import { BetterUXWrapper } from "../types/GTypes/utils";
 
 /** Tracktrix informations */
 export interface Tracker {
@@ -175,8 +160,9 @@ export type SEventsInfos = {
   SPartialABTesting &
   SPartialGooBrawlEventInfo;
 
-export {}; // this is done to make window a module
+export {}; // this is done to make parent a module
 declare global {
+  /** When you access parent via game code, this is what you have access to. */
   interface Window {
     $: JQueryStatic;
     clear_game_logs(): void;
@@ -237,47 +223,6 @@ declare global {
 
     S: SEventsInfos;
   }
-
-  /* eslint-disable no-var, vars-on-top */
-  var handle_command: undefined | ((command: string, args: string) => void);
-  var on_cm: undefined | ((from: string, data: any) => void);
-  // var on_map_click: undefined | ((x: number, y: number) => boolean);
-
-  /**
-   *
-   */
-  var on_party_invite: undefined | ((from: string) => void);
-
-  /**
-   * called by the inviter's name
-   * request = someone requesting to join your existing party
-   */
-  var on_party_request: undefined | ((from: string) => void);
-
-  var on_disappear: undefined | ((entity: Entity, data: unknown) => void);
-
-  /**
-   * called by the mage's name in PVE servers,
-   * in PVP servers magiport either succeeds or fails without consent
-   */
-  var on_magiport: undefined | ((from: string) => void);
-
-  /**
-   * if true is returned, the default move is cancelled
-   */
-  var on_map_click: undefined | ((x: number, y: number) => void);
-
-  /**
-   * called just before the CODE is destroyed
-   */
-  var on_destroy: undefined | (() => void);
-
-  /**
-   * the game calls this function at the best place in each game draw frame,
-   * so if you are playing the game at 60fps, this function gets called 60 times per second
-   */
-  var on_draw: undefined | (() => void);
-  /* eslint-enable no-var, vars-on-top */
 }
 
 export type ChestInfo = PositionReal & {

--- a/src/parent/index.ts
+++ b/src/parent/index.ts
@@ -2,7 +2,6 @@ import { BankPacksInfos } from "../bank";
 import { CharacterEntity, MonsterEntity, NpcEntity } from "../entity";
 import { PartyCharacter } from "../functions";
 import {
-  EventKey,
   GDropList,
   GDropMaps,
   GDropMonsters,

--- a/src/parent/sevent-info.ts
+++ b/src/parent/sevent-info.ts
@@ -1,4 +1,4 @@
-import { MapKey, EventKey } from "../G";
+import { MapKey } from "../G";
 import { BetterUXWrapper } from "../types/GTypes/utils";
 
 /** NOTE: Some event monsters don't have x and y (e.g.: Slenderman) */

--- a/src/parent/sevent-info.ts
+++ b/src/parent/sevent-info.ts
@@ -1,0 +1,101 @@
+import { MapKey, EventKey } from "../G";
+import { BetterUXWrapper } from "../types/GTypes/utils";
+
+/** NOTE: Some event monsters don't have x and y (e.g.: Slenderman) */
+
+export type SMonsterEventLive = {
+  /** Is the monster currently available? */
+  live: true;
+  map: MapKey;
+
+  hp: number;
+  max_hp: number;
+
+  /** The character name that the monster is currently attacking */
+  target?: string | null;
+
+  /** A date string of when the event will end */
+  end?: Date;
+};
+
+export type SMonsterEventLiveWithCoordinates = SMonsterEventLive & {
+  x: number;
+  y: number;
+};
+
+// TODO: don't think all events has live / spawn when not live
+export type SMonsterEventNotLive = {
+  /** Is the monster currently available? */
+  live: false;
+
+  /** At what date will the monster spawn? */
+  spawn: string;
+};
+
+export type SMonsterEvent = BetterUXWrapper<SMonsterEventNotLive | SMonsterEventLive>;
+export type SMonsterEventWithCoordinates = BetterUXWrapper<
+  SMonsterEventNotLive | SMonsterEventLiveWithCoordinates
+>;
+
+
+export type SEventsInfos = {
+  schedule: {
+    time_offset: number;
+    dailies: Array<number>;
+    nightlies: Array<number>;
+    night: boolean;
+  };
+} & {
+  /** `wabbit` spawns hourly on a random map and inside a random monster pack. 
+   * It's super hard to kill for 5 minutes, which should give you enough time to join the fight! 
+   * read more: https://adventure.land/docs/ref/event-egghunt */
+  egghunt: boolean;
+  wabbit: SMonsterEvent
+
+  /** `pinkgoo` spawns every hour in a random map and inside a random monster pack. 
+   * Love Goo is co-op but has 98% avoidance, so it's a bit tricky to land a hit! 
+   * read more: https://adventure.land/docs/ref/event-valentines */
+  valentines: boolean;
+  pinkgoo: SMonsterEvent
+  
+  /** read more: https://adventure.land/docs/ref/event-lunarnewyear */
+  lunarnewyear: boolean;
+  /** lunarnewyear: Dragold spanws every 3 hours. Take a chance to capture one of the very rare drops. A unique crown as a cosmetics item and Dragold's chrysalis! (to have a Dragold as a pet!) */
+  dragold:SMonsterEventWithCoordinates;
+  /** lunarnewyear: The Legendary Tiger appears to players and drops Tiger set items each time you manage to land a hit! Make sure to not hurt this peaceful and giving animal! */
+  tiger:SMonsterEventWithCoordinates;
+
+  /** read more https://adventure.land/docs/ref/event-holidayseason */
+  holidayseason: boolean;
+  grinch: SMonsterEventWithCoordinates;
+  /** snowman spawns more often during holiday season */
+  snowman: SMonsterEventWithCoordinates;
+
+  /** read more: https://adventure.land/docs/ref/event-halloween */
+  halloween: boolean;
+  mrpumpkin: SMonsterEventWithCoordinates;
+  mrgreen: SMonsterEventWithCoordinates;
+  slenderma: SMonsterEvent;
+
+  /** read more: https://adventure.land/docs/ref/event-goobrawl */
+  goobrawl: {
+    /** A date string of when the event will end */
+    end?: string;
+  };
+
+  /** read more: https://adventure.land/docs/ref/event-abtesting */
+  abtesting: {
+    /** A date string of when the event will end */
+    end?: string;
+
+    /** A date string of when sign-ups will stop for the event */
+    signup_end: string;
+
+    /** How many characters are on team A. TODO: Check that this is actually what it means */
+    A: number;
+    /** How many characters are on team B. TODO: Check that this is actually what it means */
+    B: number;
+    /** The event ID. TODO: Do we need this? */
+    id: string;
+  };
+};

--- a/src/parent/sevent-info.ts
+++ b/src/parent/sevent-info.ts
@@ -98,4 +98,12 @@ export type SEventsInfos = {
     /** The event ID. TODO: Do we need this? */
     id: string;
   };
+
+  /**
+   * Giga Crab is a challenging server event boss. 
+   * As long as there are Huge Crabs around, Giga Crab only receives one damage! 
+   * The entire server needs to get together to continually clear all the Huge Crabs that spawn. 
+   * The event lasts 40 minutes but as long as Giga Crab is being engaged, the event goes on! 
+   * read more: https://adventure.land/docs/ref/event-crabxx */
+  crabxx: SMonsterEventWithCoordinates;
 };

--- a/src/parent/sevent-info.ts
+++ b/src/parent/sevent-info.ts
@@ -105,5 +105,12 @@ export type SEventsInfos = {
    * The entire server needs to get together to continually clear all the Huge Crabs that spawn. 
    * The event lasts 40 minutes but as long as Giga Crab is being engaged, the event goes on! 
    * read more: https://adventure.land/docs/ref/event-crabxx */
-  crabxx: SMonsterEventWithCoordinates;
+   crabxx: SMonsterEventWithCoordinates;
+
+   /** read more: https://adventure.land/docs/ref/event-franky */
+   franky: SMonsterEventWithCoordinates;
+   /**
+    * icegolem is located on a closed island, make sure to not get stuck when the event is over. 
+    * read more: https://adventure.land/docs/ref/event-icegolem */
+   icegolem: SMonsterEventWithCoordinates;
 };

--- a/src/position.ts
+++ b/src/position.ts
@@ -1,4 +1,13 @@
 import { MapKey } from "./types/GTypes/maps";
+export interface ICoord {
+  x: number;
+  y: number;
+}
+
+export interface ICoordReal {
+  real_x: number;
+  real_y: number;
+}
 
 export type IPosition = {
   /**

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -24,10 +24,12 @@ export type SkillKey_NoParameter = Extract<
   | "selfheal"
   | "stomp"
   | "warcry"
+  | "dash"
 >;
 
 export type SkillKey_TargetParameter = Extract<
   SkillKey,
+  | "attack"
   | "4fingers"
   | "absorb"
   | "burst"
@@ -45,6 +47,10 @@ export type SkillKey_TargetParameter = Extract<
   | "supershot"
   | "taunt"
   | "zapperzap"
+  | "smash"
+  | "charm"
+  | "heal" 
+  | "purify"
 >;
 
 export type SkillKey_ItemNeeded = Extract<SkillKey, "pcoat" | "shadowstrike">;
@@ -53,8 +59,14 @@ export type SkillKey_ItemAndTargetNeeded = Extract<
   SkillKey,
   "entangle" | "poisonarrow" | "revive" | "snowball"
 >;
+//  TODO: you can't supply coordinates to dash
+// else if(name=="dash")
+// 	{
+// 		var d=character.direction;
+// 		socket.emit("skill",{name:"dash",x:get_x(character)+[0,-40,40,0][d],y:get_y(character)+[40,0,0,-40][d]});
+// 	}
 
-export type SkillKey_CoordinatesNeeded = Extract<SkillKey, "blink" | "dash">;
+export type SkillKey_CoordinatesNeeded = Extract<SkillKey, "blink">;
 
 export type SkillTarget = string | { id: string };
 
@@ -71,30 +83,77 @@ declare global {
     pos: [x: number, y: number]
   ): Promise<unknown>;
 
+  // cburst with no target
+  // var hostiles=get_nearby_hostiles({range:character.range-2,limit:12}),targets=[],mp=character.mp-200,hmp=parseInt(mp/hostiles.length);
+	// 		hostiles.forEach(function(hostile){
+	// 			targets.push([hostile.id,hmp]);
+	// 		});
+
   /** The string is the ID of the target, the number is how much mana to spend on the attack */
   function use_skill(
     name: "cburst",
     targets: [target: SkillTarget, mana: number][]
   ): Promise<unknown>;
 
-  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
-  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
-  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
+  // if(target && is_array(target))
+	// 	for(var i=0;i<target.length;i++)
+	// 	{
+	// 		if(target[i] && target[i].id) target[i]=target[i].id; // "3shot", "5shot"
+	// 		if(target[i] && target[i][0] && target[i][0].id) target[i][0]=target[i][0].id; // "cburst"
+	// 	}
 
-  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
-  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
-  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
-  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 4>): Promise<Tuple<unknown, 4>>;
-  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 5>): Promise<Tuple<unknown, 5>>;
+  /** if no target is supplied, it will find 3 targets in character.range-2 */
+  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
+  /** if no target is supplied, it will find 3 targets in character.range-2 */
+  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
+  /** if no target is supplied, it will find 3 targets in character.range-2 */
+  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
+
+  /** if no target is supplied, it will find 5 targets in character.range-2 */
+  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
+  /** if no target is supplied, it will find 5 targets in character.range-2 */
+  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
+  /** if no target is supplied, it will find 5 targets in character.range-2 */
+  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
+  /** if no target is supplied, it will find 5 targets in character.range-2 */
+  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 4>): Promise<Tuple<unknown, 4>>;
+  /** if no target is supplied, it will find 5 targets in character.range-2 */
+  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 5>): Promise<Tuple<unknown, 5>>;
 
   function use_skill(name: "throw", target: SkillTarget, inventorySlot: number): Promise<unknown>;
 
   function use_skill(name: "energize", target: SkillTarget, mp: number): Promise<unknown>;
 
-  // TODO: Skills accepting a target have `G.skills[name].target` set.
+  // TODO: Skills accepting a target have `G.skills[name].target` set. 
+  // Object.entries(G.skills).filter(([x,y]) => y.target)
+  // mtangle but it seems like it's a monster ability, and not a skill, type is monster
   // TODO: G.skills[name].target can be `true`, `"player"` or `"monster"`.
 
-  function use_skill(name: SkillKey_TargetParameter, target: SkillTarget): Promise<unknown>;
+  /**
+   * Skills expecting a target will default to the current target if none is explicitely specified.
+   */
+  function use_skill(name: SkillKey_TargetParameter, target?: SkillTarget): Promise<unknown>;
 
   function use_skill(name: SkillKey_NoParameter): Promise<unknown>;
+
+  // TODO: warp?
+  // else if(name=="warp")
+	// {
+	// 	if(target && is_string(target) && !target[2]) target[2]=character.map;
+	// 	else if(!target || !target[2] || is_string(target)) 
+	// 	{
+	// 		var trset=false;
+	// 		for(var id in G.maps)
+	// 		{
+	// 			var map=G.maps[id];
+	// 			if(map.ignore || map.instance) continue;
+	// 			map.spawns.forEach(function(s){
+	// 				if(trset) return;
+	// 				if(Math.random()<0.02) trset=true,target=[s[0],s[1],id];
+	// 			});
+	// 		}
+	// 		if(!trset) target=[Math.random()*100,Math.random()*100,"main"];
+	// 	}
+	// 	socket.emit("skill",{name:"warp",x:target[0],y:target[1],'in':target[2]});
+	// }
 }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -49,7 +49,7 @@ export type SkillKey_TargetParameter = Extract<
   | "zapperzap"
   | "smash"
   | "charm"
-  | "heal" 
+  | "heal"
   | "purify"
 >;
 
@@ -85,9 +85,9 @@ declare global {
 
   // cburst with no target
   // var hostiles=get_nearby_hostiles({range:character.range-2,limit:12}),targets=[],mp=character.mp-200,hmp=parseInt(mp/hostiles.length);
-	// 		hostiles.forEach(function(hostile){
-	// 			targets.push([hostile.id,hmp]);
-	// 		});
+  // 		hostiles.forEach(function(hostile){
+  // 			targets.push([hostile.id,hmp]);
+  // 		});
 
   /** The string is the ID of the target, the number is how much mana to spend on the attack */
   function use_skill(
@@ -96,35 +96,33 @@ declare global {
   ): Promise<unknown>;
 
   // if(target && is_array(target))
-	// 	for(var i=0;i<target.length;i++)
-	// 	{
-	// 		if(target[i] && target[i].id) target[i]=target[i].id; // "3shot", "5shot"
-	// 		if(target[i] && target[i][0] && target[i][0].id) target[i][0]=target[i][0].id; // "cburst"
-	// 	}
+  // 	for(var i=0;i<target.length;i++)
+  // 	{
+  // 		if(target[i] && target[i].id) target[i]=target[i].id; // "3shot", "5shot"
+  // 		if(target[i] && target[i][0] && target[i][0].id) target[i][0]=target[i][0].id; // "cburst"
+  // 	}
 
   /** if no target is supplied, it will find 3 targets in character.range-2 */
-  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
-  /** if no target is supplied, it will find 3 targets in character.range-2 */
-  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
-  /** if no target is supplied, it will find 3 targets in character.range-2 */
-  function use_skill(name: "3shot", targets?: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
+  function use_skill(name: "3shot"): Promise<Array<unknown>>;
+
+  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
+  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
+  function use_skill(name: "3shot", targets: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
 
   /** if no target is supplied, it will find 5 targets in character.range-2 */
-  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
-  /** if no target is supplied, it will find 5 targets in character.range-2 */
-  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
-  /** if no target is supplied, it will find 5 targets in character.range-2 */
-  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
-  /** if no target is supplied, it will find 5 targets in character.range-2 */
-  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 4>): Promise<Tuple<unknown, 4>>;
-  /** if no target is supplied, it will find 5 targets in character.range-2 */
-  function use_skill(name: "5shot", targets?: Tuple<SkillTarget, 5>): Promise<Tuple<unknown, 5>>;
+  function use_skill(name: "5shot"): Promise<Array<unknown>>;
+
+  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 1>): Promise<Tuple<unknown, 1>>;
+  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 2>): Promise<Tuple<unknown, 2>>;
+  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 3>): Promise<Tuple<unknown, 3>>;
+  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 4>): Promise<Tuple<unknown, 4>>;
+  function use_skill(name: "5shot", targets: Tuple<SkillTarget, 5>): Promise<Tuple<unknown, 5>>;
 
   function use_skill(name: "throw", target: SkillTarget, inventorySlot: number): Promise<unknown>;
 
   function use_skill(name: "energize", target: SkillTarget, mp: number): Promise<unknown>;
 
-  // TODO: Skills accepting a target have `G.skills[name].target` set. 
+  // TODO: Skills accepting a target have `G.skills[name].target` set.
   // Object.entries(G.skills).filter(([x,y]) => y.target)
   // mtangle but it seems like it's a monster ability, and not a skill, type is monster
   // TODO: G.skills[name].target can be `true`, `"player"` or `"monster"`.
@@ -138,22 +136,22 @@ declare global {
 
   // TODO: warp?
   // else if(name=="warp")
-	// {
-	// 	if(target && is_string(target) && !target[2]) target[2]=character.map;
-	// 	else if(!target || !target[2] || is_string(target)) 
-	// 	{
-	// 		var trset=false;
-	// 		for(var id in G.maps)
-	// 		{
-	// 			var map=G.maps[id];
-	// 			if(map.ignore || map.instance) continue;
-	// 			map.spawns.forEach(function(s){
-	// 				if(trset) return;
-	// 				if(Math.random()<0.02) trset=true,target=[s[0],s[1],id];
-	// 			});
-	// 		}
-	// 		if(!trset) target=[Math.random()*100,Math.random()*100,"main"];
-	// 	}
-	// 	socket.emit("skill",{name:"warp",x:target[0],y:target[1],'in':target[2]});
-	// }
+  // {
+  // 	if(target && is_string(target) && !target[2]) target[2]=character.map;
+  // 	else if(!target || !target[2] || is_string(target))
+  // 	{
+  // 		var trset=false;
+  // 		for(var id in G.maps)
+  // 		{
+  // 			var map=G.maps[id];
+  // 			if(map.ignore || map.instance) continue;
+  // 			map.spawns.forEach(function(s){
+  // 				if(trset) return;
+  // 				if(Math.random()<0.02) trset=true,target=[s[0],s[1],id];
+  // 			});
+  // 		}
+  // 		if(!trset) target=[Math.random()*100,Math.random()*100,"main"];
+  // 	}
+  // 	socket.emit("skill",{name:"warp",x:target[0],y:target[1],'in':target[2]});
+  // }
 }

--- a/src/socket-events/server-to-client/events/ServerToClient_tracker.ts
+++ b/src/socket-events/server-to-client/events/ServerToClient_tracker.ts
@@ -1,3 +1,3 @@
-import { Tracker } from "../../../window";
+import { Tracker } from "../../../parent";
 
 export type ServerToClient_tracker = Tracker;

--- a/src/types/GTypes/items/index.ts
+++ b/src/types/GTypes/items/index.ts
@@ -51,6 +51,7 @@ export * from "./UpgradeScroll";
 export * from "./Weapon";
 export * from "./XP";
 
+import { StatType } from "../../..";
 import type { BetterUXWrapper } from "../utils";
 import type { ActivatorKey, GActivator } from "./Activator";
 import type { AmuletKey, GAmulet } from "./Amulet";
@@ -161,6 +162,8 @@ export type ItemKey =
 
 type GItemDynamic = {
   buy: boolean | undefined;
+  upgrade: Partial<Record<StatType, number>>;
+  compound: Partial<Record<StatType, number>>;
 };
 
 export type GItemRaw = GItemDynamic &

--- a/src/types/GTypes/monsters/Monsters.ts
+++ b/src/types/GTypes/monsters/Monsters.ts
@@ -351,6 +351,7 @@ export interface GMonster {
   immune?: boolean;
   lifesteal?: number;
   mp: number;
+  max_hp: number;
   name: MonsterName;
   operator?: boolean;
   orientation?: number;

--- a/src/window.ts
+++ b/src/window.ts
@@ -14,7 +14,7 @@ import {
   MonsterKey,
   EventKey,
 } from "./G";
-import { IPosition, PositionReal } from "./position";
+import { PositionReal } from "./position";
 import { ServerIdentifier, ServerRegion } from "./server";
 import { SocketWithEventsFunctions } from "./socket-events";
 import { SkillKey } from "./types/GTypes/skills";

--- a/src/window.ts
+++ b/src/window.ts
@@ -108,7 +108,7 @@ export type SEventsInfos = {
 export {}; // this is done to make window a module
 declare global {
   interface Window {
-    //   $: JQueryStatic;
+    $: JQueryStatic;
     clear_game_logs(): void;
     close_merchant(): void;
     //   distance(from: IPosition | PositionReal, to: IPosition | PositionReal): number;

--- a/src/window.ts
+++ b/src/window.ts
@@ -2,7 +2,6 @@ import { BankPacksInfos } from "./bank";
 import { CharacterEntity } from "./entities/character-entity";
 import { MonsterEntity } from "./entities/monster-entity";
 import { NpcEntity } from "./entities/npc-entity";
-import { Entity } from "./entity";
 import { PartyCharacter } from "./functions";
 import {
   MapKey,
@@ -111,7 +110,7 @@ export type SEventsInfos = {
     holidayseason?: boolean; // unsure if this will override the above general purpose EventKey
   } & Partial<Record<"grinch" | "snowman", SMonsterEvent>> & {
     valentines?: boolean;
-  }& {
+  } & {
     // halloween
     halloween?: boolean; // unsure if this will override the above general purpose EventKey
   } & Partial<Record<"mrpumpkin" | "mrgreen", SMonsterEvent>>;
@@ -139,14 +138,12 @@ declare global {
 
     open_chest(id: string | number): Promise<void>;
     d_text(message: string, entity: CharacterEntity, args?: { color: string }): void;
-    //   is_disabled(entity: Entity): boolean;
 
     X: {
       characters: Array<XOnlineCharacter>;
       servers: Array<XServerInfos>;
     };
 
-    //   character: CharacterEntity;
     chests: {
       [id: string]: ChestInfo;
     };
@@ -162,8 +159,10 @@ declare global {
     party_list: string[];
     /** Contains a list of the last 40 ping response times */
     pings: number[];
-    //   server_identifier: ServerIdentifier;
-    //   server_region: ServerRegion;
+
+    server_identifier: ServerIdentifier;
+    server_region: ServerRegion;
+    
     socket: Omit<SocketIO.Socket, keyof SocketWithEventsFunctions> & SocketWithEventsFunctions;
 
     tracker: Record<string, never> | Tracker;
@@ -177,9 +176,6 @@ declare global {
     drawings: Array<PIXI.Graphics>;
 
     S: SEventsInfos;
-
-    server_region: ServerRegion;
-    server_identifier: ServerIdentifier;
   }
 
   /* eslint-disable no-var, vars-on-top */
@@ -189,8 +185,6 @@ declare global {
   var on_party_invite: undefined | ((from: string) => void);
   var on_party_request: undefined | ((from: string) => void);
   /* eslint-enable no-var, vars-on-top */
-
-  
 }
 
 export type ChestInfo = PositionReal & {

--- a/src/window.ts
+++ b/src/window.ts
@@ -15,6 +15,7 @@ import {
   EventKey,
 } from "./G";
 import { IPosition, PositionReal } from "./position";
+import { ServerIdentifier, ServerRegion } from "./server";
 import { SocketWithEventsFunctions } from "./socket-events";
 import { SkillKey } from "./types/GTypes/skills";
 import { BetterUXWrapper } from "./types/GTypes/utils";
@@ -176,6 +177,9 @@ declare global {
     drawings: Array<PIXI.Graphics>;
 
     S: SEventsInfos;
+
+    server_region: ServerRegion;
+    server_identifier: ServerIdentifier;
   }
 
   /* eslint-disable no-var, vars-on-top */

--- a/src/window.ts
+++ b/src/window.ts
@@ -90,8 +90,9 @@ export type SMonsterEventLive = {
   /** Is the monster currently available? */
   live: true;
 
-  x: number;
-  y: number;
+  /** NOTE: Some event monsters don't have x and y (e.g.: Slenderman) */
+  x?: number;
+  y?: number;
   map: MapKey;
 
   hp: number;
@@ -102,6 +103,7 @@ export type SMonsterEventLive = {
   end?: Date;
 };
 
+// TODO: don't think all events has live / spawn when not live
 export type SMonsterEventNotLive = {
   /** Is the monster currently available? */
   live: false;
@@ -112,6 +114,53 @@ export type SMonsterEventNotLive = {
 
 export type SMonsterEvent = BetterUXWrapper<SMonsterEventNotLive | SMonsterEventLive>;
 
+export type SEventBooleanKeys =
+  | "egghunt"
+  | "halloween"
+  | "holidayseason"
+  | "lunarnewyear"
+  | "valentines";
+
+export type SPartialEventBoolean = Partial<Record<Extract<SEventBooleanKeys, EventKey>, boolean>>;
+
+// TODO: should we just use MonsterKey?
+export type SPartialEventMonsterEvent = Partial<
+  Record<Exclude<EventKey, SEventBooleanKeys | "abtesting" | "goobrawl">, SMonsterEvent>
+>;
+export type SPartialHolidaySeasonMonsters = Partial<Record<"grinch" | "snowman", SMonsterEvent>>;
+export type SPartialHalloweenMonsters = Partial<
+  Record<"mrpumpkin" | "mrgreen" | "slenderman", SMonsterEvent>
+>;
+
+export type SPartialABTesting = Partial<
+  Record<
+    "abtesting",
+    {
+      /** A date string of when the event will end */
+      end?: string;
+
+      /** A date string of when sign-ups will stop for the event */
+      signup_end: string;
+      /** How many characters are on team A. TODO: Check that this is actually what it means */
+      A: number;
+      /** How many characters are on team B. TODO: Check that this is actually what it means */
+      B: number;
+      /** The event ID. TODO: Do we need this? */
+      id: string;
+    }
+  >
+>;
+
+export type SPartialGooBrawlEventInfo = Partial<
+  Record<
+    "abtesting",
+    {
+      /** A date string of when the event will end */
+      end?: string;
+    }
+  >
+>;
+
 export type SEventsInfos = {
   schedule: {
     time_offset: number;
@@ -119,17 +168,12 @@ export type SEventsInfos = {
     nightlies: Array<number>;
     night: boolean;
   };
-} & Partial<Record<EventKey, SMonsterEvent>> & {
-    // Christmas
-    holidayseason?: boolean; // unsure if this will override the above general purpose EventKey
-  } & Partial<Record<"grinch" | "snowman", SMonsterEvent>> & {
-    valentines?: boolean;
-  } & {
-    // halloween
-    halloween?: boolean; // unsure if this will override the above general purpose EventKey
-  } & Partial<Record<"mrpumpkin" | "mrgreen", SMonsterEvent>> & {
-    crabxx?: SMonsterEvent;
-  };
+} & SPartialEventBoolean &
+  SPartialEventMonsterEvent &
+  SPartialHolidaySeasonMonsters &
+  SPartialHalloweenMonsters &
+  SPartialABTesting &
+  SPartialGooBrawlEventInfo;
 
 export {}; // this is done to make window a module
 declare global {

--- a/src/window.ts
+++ b/src/window.ts
@@ -2,6 +2,7 @@ import { BankPacksInfos } from "./bank";
 import { CharacterEntity } from "./entities/character-entity";
 import { MonsterEntity } from "./entities/monster-entity";
 import { NpcEntity } from "./entities/npc-entity";
+import { Entity } from "./entity";
 import { PartyCharacter } from "./functions";
 import {
   MapKey,
@@ -11,8 +12,9 @@ import {
   GDropNormalDrops,
   ItemKey,
   MonsterKey,
+  EventKey,
 } from "./G";
-import { PositionReal } from "./position";
+import { IPosition, PositionReal } from "./position";
 import { SocketWithEventsFunctions } from "./socket-events";
 import { SkillKey } from "./types/GTypes/skills";
 import { BetterUXWrapper } from "./types/GTypes/utils";
@@ -83,12 +85,17 @@ export interface XServerInfos {
   region: string;
 }
 
-export type SMonsterEvent = {
+export type SMonsterEvent = IPosition & {
   /** Is the monster currently available? */
   live: boolean;
 
   /** At what date will the monster spawn? */
   spawn: string;
+
+  hp: number;
+  max_hp: number;
+  /** The character name that the monster is currently attacking */
+  target?: string;
 };
 
 export type SEventsInfos = {
@@ -98,12 +105,15 @@ export type SEventsInfos = {
     nightlies: Array<number>;
     night: boolean;
   };
-} & {
-  // Christmas
-  holidayseason?: boolean;
-  grinch?: SMonsterEvent;
-  snowman?: SMonsterEvent;
-};
+} & Partial<Record<EventKey, SMonsterEvent>> & {
+    // Christmas
+    holidayseason?: boolean; // unsure if this will override the above general purpose EventKey
+  } & Partial<Record<"grinch" | "snowman", SMonsterEvent>> & {
+    valentines?: boolean;
+  }& {
+    // halloween
+    halloween?: boolean; // unsure if this will override the above general purpose EventKey
+  } & Partial<Record<"mrpumpkin" | "mrgreen", SMonsterEvent>>;
 
 export {}; // this is done to make window a module
 declare global {
@@ -166,21 +176,6 @@ declare global {
     drawings: Array<PIXI.Graphics>;
 
     S: SEventsInfos;
-
-    //   S: {
-    //     [T in EventName]?: IPosition & {
-    //       map: string;
-    //       live: boolean;
-    //       hp: number;
-    //       max_hp: number;
-    //       /** The character name that the monster is currently attacking */
-    //       target?: string;
-    //       x?:number;
-    //       y?:number
-    //     };
-    //   } & {
-    //     valentines?: boolean;
-    //   };
   }
 
   /* eslint-disable no-var, vars-on-top */
@@ -190,6 +185,8 @@ declare global {
   var on_party_invite: undefined | ((from: string) => void);
   var on_party_request: undefined | ((from: string) => void);
   /* eslint-enable no-var, vars-on-top */
+
+  
 }
 
 export type ChestInfo = PositionReal & {


### PR DESCRIPTION
- typed `character.items` to better distinquish between the types of items
- export monsterhunt status info so it can be used
- added is_silenced 
- added is_disabled
- added merchants as a possible type response from api_response
- dash should be a non targeted skill according to use_skill, needs to be verified
- added attack, smash, charm, heal, purify to targeted skills
- targeted skills can also be used without a target and the client will find a target or use your current target.
- type upgrade and compound with an indexer property for stat type
- added missing max_hp from GMonster
- added all EventKey as an indexer on parent.S
- used a specific indexer for some event types not present in EventKey
- Added jQuery to parent.$
- added server_identifier and server_region